### PR TITLE
custom controls on mobile

### DIFF
--- a/src/media.youtube.js
+++ b/src/media.youtube.js
@@ -33,9 +33,9 @@ videojs.Youtube = videojs.MediaTechController.extend({
     this.player_el_.className += ' vjs-youtube';
 
     // Mobile devices are using their own native players
-    if (!!navigator.userAgent.match(/iPhone/i) || !!navigator.userAgent.match(/iPad/i) || !!navigator.userAgent.match(/iPod/i) || !!navigator.userAgent.match(/Android.*AppleWebKit/i)) {
+    /*if (!!navigator.userAgent.match(/iPhone/i) || !!navigator.userAgent.match(/iPad/i) || !!navigator.userAgent.match(/iPod/i) || !!navigator.userAgent.match(/Android.*AppleWebKit/i)) {
       player.options()['ytcontrols'] = true;
-    }
+    }*/
 
     // Create the Quality button
     this.qualityButton = document.createElement('div');
@@ -94,6 +94,13 @@ videojs.Youtube = videojs.MediaTechController.extend({
       
       e.stopPropagation();
       e.preventDefault();
+    });
+    this.iframeblocker.addEventListener('tap', function(){
+      if (self.player_.userActive() === true) {
+        self.player_.userActive(false);
+      } else {
+        self.player_.userActive(true);
+      }
     });
 
     if (!this.player_.options()['ytcontrols']) {


### PR DESCRIPTION
add tap function to show and hide controls \* disable native controls.
need to add .vjs-poster, .vjs-loading-spinner, .vjs-big-play-button, .vjs-text-track-display{
    pointer-events: none !important;
} to css.

to do: 
*detect if browser supports fullscreen if not use native controls.
- hide native controls on browsers that do not support full screen
  http://css-tricks.com/custom-controls-in-html5-video-full-screen/
