### PR TITLE
IE dynamic CSS-add fix

### DIFF
--- a/src/media.youtube.js
+++ b/src/media.youtube.js
@@ -613,12 +613,18 @@ videojs.Youtube.prototype.onError = function(error){
 // Keep the iframeblocker in front of the player when the user is inactive
 // (ONLY way because the iframe is so selfish with events)
 (function() {
-  var style = document.createElement('style');
-  style.innerText = ' \
+  var styleText = ' \
   .vjs-youtube .vjs-poster { background-size: cover; }\
   .iframeblocker { display:none;position:absolute;top:0;left:0;width:100%;height:100%;cursor:pointer;z-index:2; }\
   .vjs-youtube.vjs-user-inactive .iframeblocker { display:block; } \
   .vjs-quality-button > div:first-child > span:first-child { position:relative;top:7px }\
   ';
+  var style = document.createElement('style');
+  style.type = 'text/css';
+  if(style.styleSheet) { // IE
+    style.styleSheet.cssText = styleText;
+  } else { // sane browsers
+    style.innerText = styleText;
+  }
   document.getElementsByTagName('head')[0].appendChild(style);
 })();


### PR DESCRIPTION
videojs-youtube has a number of IE compatibility issues, but as long as you only need to support IE8+, most can be fixed with polyfills - namely the following:
classList IE10+
getElementsByClassName IE9+
addEventListener/removeEventListener IE9+

IE versions prior to IE9 don't support style.innerText, and additionally require 'text/sss' mime-type to be set on the element's type property. This requires so little code to fix that I believe it's appropriate to include in the plugin.
