### PR TITLE
fix youtube play on mobile

### DIFF
--- a/src/media.youtube.js
+++ b/src/media.youtube.js
@@ -615,6 +615,7 @@ videojs.Youtube.prototype.onError = function(error){
 (function() {
   var styleText = ' \
   .vjs-youtube .vjs-poster { background-size: cover; }\
+  .vjs-poster, .vjs-loading-spinner, .vjs-big-play-button, .vjs-text-track-display{ pointer-events: none !important; }\
   .iframeblocker { display:none;position:absolute;top:0;left:0;width:100%;height:100%;cursor:pointer;z-index:2; }\
   .vjs-youtube.vjs-user-inactive .iframeblocker { display:block; } \
   .vjs-quality-button > div:first-child > span:first-child { position:relative;top:7px }\


### PR DESCRIPTION
due to a bug in youtube api, you can not play youtube iframe via js play event on mobile so the only way to get the video to play is clicking the big red button, with this simple css trick you can play the video while still having custom styles over the iframe. this css trick makes the below content (iframe) clickable while still making the above content viewable.
