### PR TITLE
Call destroy of ytplayer

### DIFF
--- a/src/youtube.js
+++ b/src/youtube.js
@@ -213,8 +213,14 @@ videojs.Youtube = videojs.MediaTechController.extend({
     }
     
     this.on('dispose', function() {
+      this.ytplayer.destroy();
+
+      // If still connected to the DOM, remove it.
+      if (this.el_.parentNode) {
+        this.el_.parentNode.removeChild(this.el_);
+      }
+
       // Get rid of the created DOM elements
-      this.el_.parentNode.removeChild(this.el_);
       this.iframeblocker.parentNode.removeChild(this.iframeblocker);
       this.qualityButton.parentNode.removeChild(this.qualityButton);
       


### PR DESCRIPTION
Correct issue in IE9 where disposing a playing video causes an error
