### PR TITLE
Added option to block play/pause click on video

### DIFF
--- a/src/youtube.js
+++ b/src/youtube.js
@@ -72,6 +72,17 @@
 
       this.player_el_.insertBefore(this.el_, this.player_el_.firstChild);
       
+	  if (this.player_.options()["blockClick"]){
+		  this.iframeClickBlock = document.createElement("div");
+		  this.iframeClickBlock.style.position = "absolute";
+		  this.iframeClickBlock.style.width = "100%";
+		  this.iframeClickBlock.style.height = "100%";
+		  this.iframeClickBlock.onclick = function(event){
+			  event.stopPropagation();
+		  };	  
+		  this.player_el_.insertBefore(this.iframeClickBlock, this.player_el_.firstChild.nextSibling);
+	  }
+	  
       if (/MSIE (\d+\.\d+);/.test(navigator.userAgent)) {
         var ieVersion = new Number(RegExp.$1);
         


### PR DESCRIPTION
Added an option that puts a div over the iframe to effectively block
clicks on the player itself. This does prevent the right click too,
however. I needed to block the ability to play/pause with the left click
because I wanted to track when user does those actions via the control
bar. Don't use this options with ytcontrols enabled.
