### PR TITLE
Limits pointer event disabling to YouTube videos alone

### DIFF
--- a/src/youtube.js
+++ b/src/youtube.js
@@ -712,7 +712,10 @@
   var style = document.createElement('style');
   var def = ' \
   .vjs-youtube .vjs-poster { background-size: 100%!important; }\
-  .vjs-poster, .vjs-loading-spinner, .vjs-big-play-button, .vjs-text-track-display{ pointer-events: none !important; }\
+  .vjs-youtube .vjs-poster, .vjs-youtube .vjs-loading-spinner, \
+    .vjs-youtube .vjs-big-play-button, .vjs-youtube .vjs-text-track-display{\
+      pointer-events: none !important;\
+   }\
   .vjs-youtube.vjs-user-active .iframeblocker { display: none; }\
   .vjs-youtube.vjs-user-inactive .vjs-tech.onDesktop { pointer-events: none; }\
   .vjs-quality-button > div:first-child > span:first-child { position:relative;top:7px }\


### PR DESCRIPTION
When using this plugin on the same page as a native HTML5 video, the YouTube plugin sets certain styles that affect certain features of the native player. For example, the big play button no longer gives a pointer for HTML5 videos. (And in some instances, like with audio elements, cannot be clicked on, preventing playback.)

Compare the [default behavior](http://jsfiddle.net/788bE/1/) with the [behavior when the YouTube plugin is present](http://jsfiddle.net/788bE/).

This pull request specifies that these CSS properties only apply to YouTube videos, rather than all Video.js instances.
