### PR TITLE
Adding timeupdate and duration change event triggers so the control bar ...

### DIFF
--- a/src/youtube.js
+++ b/src/youtube.js
@@ -546,6 +546,13 @@
 
     this.player_.trigger('loadedmetadata');
 
+    // The duration is loaded so we might as well fire off the timeupdate and duration events
+    // this allows for the duration of the video (timeremaining) to be displayed if styled
+    // to show the control bar initially. This gives the user the ability to see how long the video 
+    // is before clicking play
+    this.player_.trigger('timeupdate');
+    this.player_.trigger('durationchange');
+
     // Let the player take care of itself as soon as the YouTube is ready
     // The loading spinner while waiting for the tech would be impossible otherwise
     if(typeof this.player_.loadingSpinner !== 'undefined') {


### PR DESCRIPTION
...can display the time before the user clicks play. I've got the control bar and time remaining component showing by default which I think is good for the user as they can see how long the video is before clicking play. 
