### PR TITLE
Removed initialisation of low res standart poster

### DIFF
--- a/src/youtube.js
+++ b/src/youtube.js
@@ -220,13 +220,6 @@
       if(this.player_.options()['ytcontrols']) {
         // Disable the video.js controls if we use the YouTube controls
         this.player_.controls(false);
-      } else if(typeof this.player_.poster() === 'undefined' || this.player_.poster().length === 0) {
-        // Don't use player.poster(), it will fail here because the tech is still null in constructor
-        setTimeout(function() {
-          var posterEl = self.playerEl_.querySelectorAll('.vjs-poster')[0];
-          posterEl.style.backgroundImage = 'url(https://img.youtube.com/vi/' + self.videoId + '/0.jpg)';
-          posterEl.style.display = '';
-        }, 100);
       }
 
       this.bindedWaiting = function() {
@@ -366,11 +359,6 @@
             suggestedQuality: this.userQuality
           });
         }
-
-        // Update the poster
-        this.playerEl_.querySelectorAll('.vjs-poster')[0].style.backgroundImage =
-          'url(https://img.youtube.com/vi/' + this.videoId + '/0.jpg)';
-        this.player_.poster('https://img.youtube.com/vi/' + this.videoId + '/0.jpg');
       }
       /* else Invalid URL */
     }


### PR DESCRIPTION
Poster should be set using the standart functionality of video.js.  e.g.

```
          myPlayer.poster(posterImage);
```

If a youtube standart poster is wanted, it could still be set via the API, following these naming conventions.
http://stackoverflow.com/questions/2068344/how-do-i-get-a-youtube-video-thumbnail-from-the-youtube-api
