### PR TITLE
Check if ytplayer exists before calling ytplayer.pauseVideo()

### DIFF
--- a/src/youtube.js
+++ b/src/youtube.js
@@ -421,7 +421,9 @@
   };
 
   videojs.Youtube.prototype.pause = function() {
-    this.ytplayer.pauseVideo();
+    if(this.ytplayer) {
+      this.ytplayer.pauseVideo();
+    }
   };
   videojs.Youtube.prototype.paused = function() {
     return (this.ytplayer) ?


### PR DESCRIPTION
We are getting occasional `Cannot read property 'pauseVideo' of undefined` errors on our webapp while creating and destroying different videojs youtube players. The simple check should fix that.