### PR TITLE
Fixed trigger to change playback rate

### DIFF
--- a/src/youtube.js
+++ b/src/youtube.js
@@ -445,7 +445,10 @@
   videojs.Youtube.prototype.setPlaybackRate = function(suggestedRate) {
     if (this.ytplayer && this.ytplayer.setPlaybackRate) {
       this.ytplayer.setPlaybackRate(suggestedRate);
-      this.player_.trigger('ratechange');
+      var self = this;
+      setTimeout(function () {
+        this.player_.trigger('ratechange');
+      }, 100);
     }
   };
   videojs.Youtube.prototype.duration = function() {
@@ -544,10 +547,12 @@
 
   // Create the YouTube player
   videojs.Youtube.prototype.loadYoutube = function() {
+    var self = this;
     this.ytplayer = new YT.Player(this.id_, {
       events: {
         onReady: function(e) {
           e.target.vjsTech.onReady();
+          self.player_.trigger('ratechange');
         },
         onStateChange: function(e) {
           e.target.vjsTech.onStateChange(e.data);


### PR DESCRIPTION
There was a problem seeing the playback rate in the pannel

![image](https://cloud.githubusercontent.com/assets/5026733/6430863/0dd944f2-c01d-11e4-81d4-6100b1a2f70f.png)

As it is seen in the last picture, there is a delay between changing the playback rate in youtube and the trigger action (ratechange). It is fixed with this pull request