### PR TITLE
Add an option to disable default youtube fullscreen controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ It supports:
 This plugin exposes the following additional [player options](https://github.com/videojs/video.js/blob/master/docs/guides/options.md):
 
 - `ytcontrols` (Boolean): Display the YouTube player controls instead of the Video.js player controls. (default `false`)
+- `ytFullScreenControls` (Boolean): Hide/Show the fullscreen controls on the default youtube player controls. Also disables/enables double click to fullscreen. (default `true`)
 - `quality` (String): Set the default video quality. Should be one of `1080p`, `720p`, `480p`, `360p`, `240p`, `144p`.
 - `playsInline` (Boolean): Sets the [`playsinline`](https://developers.google.com/youtube/player_parameters?playerVersion=HTML5#playsinline) YouTube player parameter to enable inline playback on iOS
 - `forceHTML5` (Boolean): Forces loading the YouTube HTML5 player (default `true`)

--- a/src/youtube.js
+++ b/src/youtube.js
@@ -187,6 +187,7 @@
       disablekb: 1,
       wmode: 'transparent',
       controls: (this.player_.options()['ytcontrols']) ? 1 : 0,
+      fs: (this.player_.options()['ytFullScreenControls']) ? 0 : 1,
       html5: (this.player_.options()['forceHTML5']) ? 1 : null,
       playsinline: (this.player_.options()['playsInline']) ? 1 : 0,
       showinfo: 0,
@@ -221,7 +222,7 @@
         self.triggerReady();
       }, 500);
     } else {
-      this.el_.src = 'https://www.youtube.com/embed/' + 
+      this.el_.src = 'https://www.youtube.com/embed/' +
                      (this.videoId || 'videoseries') + '?' + videojs.Youtube.makeQueryString(params);
 
       if(this.player_.options()['ytcontrols']) {


### PR DESCRIPTION
Adds
---
* `fs` option to enable/disable default youtueb fullscreen routes (button on control bar & double click to fullscreen)