### PR TITLE
Requires 4.11 or ABOVE not 4.11 only

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,6 @@
     "README.md"
   ],
   "dependencies": {
-    "video.js": "~4.11"
+    "video.js": "^4.11"
   }
 }


### PR DESCRIPTION
/srv/dev/bedrock/web/app/themes/hdav$ bower install video.js
bower cached       ...
....
...                                                                                                                                                                                                                                                                                                                                                  video.js#~4.11 which resolved to 4.11.4 and is required by videojs-youtube#1.2.10                                                                            

tests just fine and working on 4.12.6