### PR TITLE
pointing to wrong videojs bower registry

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,6 @@
     "README.md"
   ],
   "dependencies": {
-    "video.js": "^4.11"
+    "videojs": "^4.11"
   }
 }


### PR DESCRIPTION
Annoying as hell, couldnt figure out the issue until i google it...
There is videojs listed in bower registry, pointing to the main repo (i.e. useless). Might be nice to mention in some readme somewhere, had me chasing around for a bit.

$ bower search videojs
Search results:

    videojs git://github.com/videojs/video.js.git
...

$ bower search video.js
Search results:

    video.js git://github.com/videojs/video.js-component.git

github.com/videojs/video.js-component.git
^ This repository is deprecated! Don't use it unless you're really, 100% sure you need to