### PR TITLE
Make sure playbackRateMenuButton exists before updating it

### DIFF
--- a/src/youtube.js
+++ b/src/youtube.js
@@ -659,7 +659,9 @@
     this.triggerReady();
 
     this.player_.options()['playbackRates'] = this.ytplayer.getAvailablePlaybackRates();
-    this.player_.controlBar.playbackRateMenuButton.update();
+    if (this.player_.controlBar.playbackRateMenuButton) {
+      this.player_.controlBar.playbackRateMenuButton.update();
+    }
 
     this.player_.trigger('loadedmetadata');
 


### PR DESCRIPTION
As the controlbar is configurable and the the `playbackRateMenuButton` can be turned off it should be checked if it exists first before calling its `update()` method.