### PR TITLE
Enables toggleable video info

### DIFF
--- a/src/youtube.js
+++ b/src/youtube.js
@@ -229,7 +229,7 @@
       fs: fullscreenControls,
       html5: (this.player_.options()['forceHTML5']) ? 1 : null,
       playsinline: (this.player_.options()['playsInline']) ? 1 : 0,
-      showinfo: 0,
+      showinfo: (this.player_.options()['showInfo']) ? 1 : 0,
       rel: 0,
       autoplay: (this.playOnReady) ? 1 : 0,
       loop: (this.player_.options()['loop']) ? 1 : 0,


### PR DESCRIPTION
With this change, we can show video info by setting the the option 'showInfo' to true. It used to be hardcoded to false. It looks like this:

![screenshot 2015-10-06 00 26 02](https://cloud.githubusercontent.com/assets/1151489/10300793/e9697556-6bc0-11e5-85df-a7f841fbfc45.png)
