### PR TITLE
Don't call `play` in `setCurrentTime` when paused

### DIFF
--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -381,8 +381,6 @@ THE SOFTWARE. */
             this.isSeeking = false;
             clearInterval(this.checkSeekedInPauseInterval);
           }
-
-          this.play();
         }.bind(this), 250);
       }
     },


### PR DESCRIPTION
When the video is in `PlayerState.PAUSED` mode the player automatically calls `this.play()`. This makes positioning the current time in pause mode impossible.

Or is the reason force a `play` when the `currentTime` is set in pause mode?