### PR TITLE
Retain playing/paused state after seek

### DIFF
--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -223,15 +223,13 @@ THE SOFTWARE. */
           this.trigger('play');
 
           if (this.isSeeking) {
-            this.trigger('seeked');
-            this.isSeeking = false;
+            this.onSeeked();
           }
           break;
 
         case YT.PlayerState.PAUSED:
           if (this.isSeeking) {
-            this.trigger('seeked');
-            this.isSeeking = false;
+            this.onSeeked();
             this.ytPlayer.playVideo();
           } else {
             this.trigger('pause');
@@ -378,14 +376,18 @@ THE SOFTWARE. */
             clearInterval(this.checkSeekedInPauseInterval);
           } else if (this.currentTime() !== this.timeBeforeSeek) {
             this.trigger('timeupdate');
-            this.trigger('seeked');
-            this.isSeeking = false;
-            clearInterval(this.checkSeekedInPauseInterval);
+            this.onSeeked();
           }
 
           this.play();
         }.bind(this), 250);
       }
+    },
+
+    onSeeked: function() {
+      clearInterval(this.checkSeekedInPauseInterval);
+      this.trigger('seeked');
+      this.isSeeking = false;
     },
 
     playbackRate: function() {

--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -228,6 +228,7 @@ THE SOFTWARE. */
           break;
 
         case YT.PlayerState.PAUSED:
+          this.trigger('canplay');
           if (this.isSeeking) {
             this.onSeeked();
           } else {

--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -370,6 +370,7 @@ THE SOFTWARE. */
       // A seek event during pause does not return an event to trigger a seeked event,
       // so run an interval timer to look for the currentTime to change
       if (this.lastState === YT.PlayerState.PAUSED && this.timeBeforeSeek !== seconds) {
+        clearInterval(this.checkSeekedInPauseInterval);
         this.checkSeekedInPauseInterval = setInterval(function() {
           if (this.lastState !== YT.PlayerState.PAUSED || !this.isSeeking) {
             // If something changed while we were waiting for the currentTime to change,

--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -230,7 +230,6 @@ THE SOFTWARE. */
         case YT.PlayerState.PAUSED:
           if (this.isSeeking) {
             this.onSeeked();
-            this.ytPlayer.playVideo();
           } else {
             this.trigger('pause');
           }
@@ -358,7 +357,9 @@ THE SOFTWARE. */
         this.timeBeforeSeek = this.currentTime();
       }
 
-      this.timeBeforeSeek = this.currentTime();
+      if (!this.isSeeking) {
+        this.wasPausedBeforeSeek = this.paused();
+      }
 
       this.ytPlayer.seekTo(seconds, true);
       this.trigger('timeupdate');
@@ -378,8 +379,6 @@ THE SOFTWARE. */
             this.trigger('timeupdate');
             this.onSeeked();
           }
-
-          this.play();
         }.bind(this), 250);
       }
     },
@@ -388,6 +387,9 @@ THE SOFTWARE. */
       clearInterval(this.checkSeekedInPauseInterval);
       this.trigger('seeked');
       this.isSeeking = false;
+      if (this.wasPausedBeforeSeek) {
+        this.pause();
+      }
     },
 
     playbackRate: function() {


### PR DESCRIPTION
In the current 2.0.0 release, the player always starts playing after a seek. This is very unexpected when the player was paused before starting the seek.

With this pull request, the playback state is retained after the seek:
* The additional `play` and `playVideo` calls in the seek handlers have been removed.
* If the player was paused before the seek, it is paused again after the seek is completed. This is a workaround for a weird quirk in the YouTube player: when starting a seek while buffering, the player always starts playing again after the seek.

This also fixes some other bugs which popped up while working on this change:
* When quickly seeking multiple times in a row, multiple interval timers (to monitor time changes) may be started simultaneously. However, only one of them is stopped after the seek is done. In the current version, this causes the player to call `play` every 250 ms, making it impossible to pause the video afterwards. This is fixed by first clearing the old interval timer before setting a new one. (3d1103f79e73c24e7945d7c9a07312ceaef9780c)
* When seeking to an unbuffered part of the video while paused, the spinner does not disappear after the seek is completed. This is fixed by dispatching a `canplay` event on paused in order to hide the spinner. (73439ad2a8a1fc3e66e404045af60866458e258f)