### PR TITLE
Hide the poster and controls on fist tap on mobile devices

### DIFF
--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -328,12 +328,22 @@ THE SOFTWARE. */
       }
     },
 
+    parentPlayer: function(){
+        return videojs.getPlayers()[this.el_.parentNode.id];
+    },
+
     play: function() {
       if (!this.url || !this.url.videoId) {
         return;
       }
 
       if (this.isReady_) {
+          if(_isOnMobile && !this.hasPlayed){
+            this.parentPlayer().bigPlayButton.hide();
+            this.parentPlayer().posterImage.hide();
+            this.hasPlayed = true;
+            return;
+          }
         if (this.url.listId) {
           if (this.activeList === this.url.listId) {
             this.ytPlayer.playVideo();

--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -48,10 +48,6 @@ THE SOFTWARE. */
       setTimeout(function() {
         this.el_.parentNode.className += ' vjs-youtube';
 
-        if (_isOnMobile) {
-          this.el_.parentNode.className += ' vjs-youtube-mobile';
-        }
-
         if (Youtube.isApiReady) {
           this.initYTPlayer();
         } else {
@@ -61,9 +57,7 @@ THE SOFTWARE. */
     },
 
     dispose: function() {
-      this.el_.parentNode.className = this.el_.parentNode.className
-        .replace(' vjs-youtube', '')
-        .replace(' vjs-youtube-mobile', '');
+      this.el_.parentNode.className = this.el_.parentNode.className.replace(' vjs-youtube', '');
     },
 
     createEl: function() {
@@ -300,12 +294,6 @@ THE SOFTWARE. */
     },
 
     poster: function() {
-      // You can't start programmaticlly a video with a mobile
-      // through the iframe so we hide the poster and the play button (with CSS)
-      if (_isOnMobile) {
-        return null;
-      }
-
       return this.poster_;
     },
 
@@ -508,8 +496,6 @@ THE SOFTWARE. */
       };
     },
 
-
-
     supportsFullScreen: function() {
       return true;
     },
@@ -585,8 +571,7 @@ THE SOFTWARE. */
     var css = // iframe blocker to catch mouse events
               '.vjs-youtube .vjs-iframe-blocker { display: none; }' +
               '.vjs-youtube.vjs-user-inactive .vjs-iframe-blocker { display: block; }' +
-              '.vjs-youtube .vjs-poster { background-size: cover; }' +
-              '.vjs-youtube-mobile .vjs-big-play-button { display: none; }';
+              '.vjs-youtube .vjs-poster { background-size: cover; }';
 
     var head = document.head || document.getElementsByTagName('head')[0];
 

--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -175,6 +175,14 @@ THE SOFTWARE. */
           this.userActive(true);
       });
         
+      // Disable VJS controls for iPad only
+      var iPad = /iPad/.test(navigator.userAgent) && !window.MSStream;
+      if(iPad) {
+          playerVars.controls = 1; // Enable YouTube controls
+          playerVars.fs = this.options_.fs;
+          this.parentPlayer().controlBar.dispose(); // Remove VJS controls
+      }
+
       this.activeVideoId = this.url ? this.url.videoId : null;
       this.activeList = playerVars.list;
 


### PR DESCRIPTION
This should help answer your question on https://github.com/videojs/video.js/issues/2914

This uses the parent player object to hide the poster and controls when the user first taps to play the video on mobile devices. This prevents the API from calling play on the YouTube video for the fist time and reveals the YouTube video for the user to press play on. This will prevent the video from breaking on mobile devices.

I also reversed your solution to hide the poster and play button. I feel it would be a better UX to have the poster and have the user press play twice than to not show the poster at all.