### PR TITLE
update youtube.js to fix the 'youtube' tech is undefined error

### DIFF
--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -26,7 +26,7 @@ THE SOFTWARE. */
       return (root.Youtube = factory(videojs));
     });
   } else if(typeof module === 'object' && module.exports) {
-    module.exports = (root.Youtube = factory(require('video.js')));
+    module.exports = factory(require('video.js'));
   } else {
     root.Youtube = factory(root.videojs);
   }


### PR DESCRIPTION
Hello,

I've had the error `VIDEOJS: ERROR: the “YouTube” tech is undefined. Skipped browser support check for that tech` using `video.js@5.8.1` and `videojs-youtube@2.0.8` along with browserify.

Seems like this error has been fixed by editing the AMD declaration for CommonJS exports.
I don't have the error anymore with this fix!