### PR TITLE
Fix for "Error: Cannot find module 'videojs'"

### DIFF
--- a/src/Youtube.js
+++ b/src/Youtube.js
@@ -25,7 +25,7 @@ THE SOFTWARE. */
     var videojs = require('video.js');
     module.exports = factory(videojs.default || videojs);
   } else if(typeof define === 'function' && define.amd) {
-    define(['videojs'], function(videojs){
+    define(['video.js'], function(videojs){
       return (root.Youtube = factory(videojs));
     });
   } else {


### PR DESCRIPTION
Additional fix for #343.
Youtube.js defines a module with a dependency on `videojs` when it should be `video.js`.